### PR TITLE
Improve error messages on parser errors

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -29,6 +29,9 @@ int driver::parse() {
 			static_cast<yy::parser::debug_level_type>(trace_parsing));
 	int res = parse();
 	scan_end();
+	if (res != 0) {
+		return res;
+	}
 	if (modules.find("main") == modules.end()) {
 		throw NoMainModuleException();
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,12 +32,12 @@ int main(int argc, char *argv[]) {
 		}
 	}
 
-	if (drv.parse_file(filename) == 0) {
+	int parseRes = drv.parse_file(filename);
+	if (parseRes == 0) {
 		frontend.drv = &drv;
 		frontend.WriteFile();
 	} else {
-		std::cout << "Compilation error" << std::endl;
-		return 1;
+		return parseRes;
 	}
 	return 0;
 }


### PR DESCRIPTION
I changed the driver so it won't begin checking for a main module in case the parsing fails. Besides that, I also removed the "compilation error" printout, since it just duplicated and distracted from the already existing syntax error print, which is more informative.