### PR TITLE
Fixed scientific notation bug

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -15,11 +15,18 @@ std::string MAIN_MODULE = "main";
 
 namespace precision {
 
+// TODO: This does not seem ideal, but getting floats in just the right format
+// seems to be a hard problem.
 std::string to_string(double d) {
-
-	std::ostringstream stm;
-	stm << std::setprecision(std::numeric_limits<double>::digits10) << d;
-	return stm.str();
+	std::ostringstream ss;
+	ss << std::fixed;
+	ss << std::setprecision(MAX_DECS);
+	ss << d;
+	std::string out = ss.str();
+	while (out.back() == '0' || out.back() == '.') {
+		out.pop_back();
+	}
+	return out;
 }
 } // namespace precision
 

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -2,6 +2,8 @@
 #include <map>
 #include <string>
 
+#define MAX_DECS 10
+
 using specie = std::string;
 using speciesRatios = std::map<specie, int>;
 using reactionRate = double;

--- a/tests/basictest.cpp
+++ b/tests/basictest.cpp
@@ -922,37 +922,50 @@ TEST_F(BasicTest, NoArgComp) {
 
 TEST_F(BasicTest, MultipleIncludes) {
 	std::string in = "import chemlib/oscillator.chem;\n"
-		"import tests/chemfiles/include1.chem;\n"
-		"module main {\n"
-		"private: [a, b, c, d];\n"
-		"output: z;\n"
-		"concentrations: {\n"
-		"a := 3;\n"
-		"b := 3;\n"
-		"c := 3;\n"
-		"d := 3;\n"
-		"}\n"
-		"compositions: {"
-		"z = MulAdditions(a, b, c, d);"
-		"}}";
+									 "import tests/chemfiles/include1.chem;\n"
+									 "module main {\n"
+									 "private: [a, b, c, d];\n"
+									 "output: z;\n"
+									 "concentrations: {\n"
+									 "a := 3;\n"
+									 "b := 3;\n"
+									 "c := 3;\n"
+									 "d := 3;\n"
+									 "}\n"
+									 "compositions: {"
+									 "z = MulAdditions(a, b, c, d);"
+									 "}}";
 
 	std::string out = "#!/usr/bin/env -S crnsimul -e -P -C z\n"
-		"a := 3;\n"
-		"b := 3;\n"
-		"c := 3;\n"
-		"d := 3;\n"
-		"MulAdditions_0_x + MulAdditions_0_y -> MulAdditions_0_x + "
-		"MulAdditions_0_y + z;\n"
-		"z -> 0;\n"
-		"c -> MulAdditions_0_y + c;\n"
-		"d -> MulAdditions_0_y + d;\n"
-		"MulAdditions_0_y -> 0;\n"
-		"a -> MulAdditions_0_x + a;\n"
-		"b -> MulAdditions_0_x + b;\n"
-		"MulAdditions_0_x -> 0;\n";
+										"a := 3;\n"
+										"b := 3;\n"
+										"c := 3;\n"
+										"d := 3;\n"
+										"MulAdditions_0_x + MulAdditions_0_y -> MulAdditions_0_x + "
+										"MulAdditions_0_y + z;\n"
+										"z -> 0;\n"
+										"c -> MulAdditions_0_y + c;\n"
+										"d -> MulAdditions_0_y + d;\n"
+										"MulAdditions_0_y -> 0;\n"
+										"a -> MulAdditions_0_x + a;\n"
+										"b -> MulAdditions_0_x + b;\n"
+										"MulAdditions_0_x -> 0;\n";
 
 	driver drv;
 	drv.parse_string(in);
 	EXPECT_EQ(drv.Compile(), out);
+}
 
+TEST_F(BasicTest, SmallRate) {
+	std::string in = "module main {\n"
+									 "private: a;\n"
+									 "output: b;\n"
+									 "reactions: { a ->(0.00000001) b; }}";
+
+	driver drv;
+	ASSERT_EQ(drv.parse_string(in), 0);
+	std::string out = "#!/usr/bin/env -S crnsimul -e -P -C b\n"
+										"a ->(0.00000001) b;\n";
+
+	EXPECT_EQ(drv.Compile(), out);
 }


### PR DESCRIPTION
Reaction constants, when suffeciently small, would get printed in scientific notation, which is incompatible with crnsimul. This has been fixed in this commit. This should close #71.
