### PR TITLE
Fix bug where composition errors were bad

### DIFF
--- a/src/module.h
+++ b/src/module.h
@@ -57,6 +57,18 @@ struct MapConcForSubModuleException : public std::exception {
 	}
 };
 
+struct NoSuchModuleException : public std::exception {
+	std::string error;
+	NoSuchModuleException(std::string moduleName)
+			: error(
+						"You tried to create a composition with module '" + moduleName +
+						"', but no such module has been defined. Maybe it's defined below "
+						"the current module?") {}
+	const char *what() const throw() {
+		return error.c_str();
+	}
+};
+
 class Module {
 public:
 	Module() {}

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -37,6 +37,9 @@ void MergeVectors(std::vector<T> &v1, const std::vector<T> &v2) {
 }
 
 Composition *MakeComposition(driver &drv, const std::string &moduleName, std::vector<specie> inputs, std::vector<specie> outputs) {
+	if (drv.modules.find(moduleName) == drv.modules.end()) {
+		throw NoSuchModuleException(moduleName);
+	}
 	Module *module = &drv.modules.at(moduleName);
 	return new ModuleComposition(module, inputs, outputs);
 }

--- a/tests/basictest.cpp
+++ b/tests/basictest.cpp
@@ -1051,3 +1051,22 @@ TEST_F(BasicTest, ScaleRateTestDown) {
 	ASSERT_EQ(drv.parse_string(in), 0);
 	EXPECT_EQ(drv.Compile(), out);
 }
+
+TEST_F(BasicTest, CompErrorTest) {
+	std::string in = "module main {\n"
+									 "private: [a, b, c, d];\n"
+									 "output: e;\n"
+									 "concentrations: {\n"
+									 "a := 50;\n"
+									 "b := 30;\n"
+									 "c := 30;\n"
+									 "}\n"
+									 "compositions: {\n"
+									 "d = Addition(a, b);\n"
+									 "e = Addition(d, c);\n"
+									 "}\n"
+									 "}\n";
+
+	driver drv;
+	ASSERT_THROW(drv.parse_string(in), NoSuchModuleException);
+}


### PR DESCRIPTION
Instead of simply throwing a std::out_of_range, we will now specify that the given module is not defined. This should help people out. This should close #23.
